### PR TITLE
Fix: Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip xvfb && \
   apt clean && \
-  rm -rf /var/libs/apt/lists/* /tmp/* /var/tmp/* \
-  pip3 install pyopengl glfw pillow numpy pyrr
+  rm -rf /var/libs/apt/lists/* /tmp/* /var/tmp/*
+
+# Install python packages
+RUN pip3 install pyopengl glfw pillow numpy pyrr
 
 COPY ./whippersnapper /whippersnapper
 
 WORKDIR /whippersnapper
 ENTRYPOINT ["xvfb-run","python3","whippersnapper.py"]
 CMD ["--help"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3pip xvfb && \
+    python3 python3-pip xvfb && \
   apt clean && \
   rm -rf /var/libs/apt/lists/* /tmp/* /var/tmp/* \
   pip3 install pyopengl glfw pillow numpy pyrr

--- a/README.md
+++ b/README.md
@@ -26,7 +26,28 @@ xvfb-run python3 whipersnapper.py ...
 
 ## Usage:
 
+### Docker:
 
+The whippersnapper program can be run within a docker container to capture
+a snapshot by building the provided Docker image and running a container as
+follows:
+```
+docker build --rm=true -t whippersnapper -f ./Dockerfile .
+```
+```
+docker run --rm --init --name my_whippersnapper -v $SURF_SUBJECT_DIR:/surf_subject_dir \
+                                                -v $OVERLAY_DIR:/overlay_dir \
+                                                -v $OUTPUT_DIR:/output_dir \
+                                                --user $(id -u):$(id -g) whippersnapper:latest \
+                                                --lh_overlay /overlay_dir/$LH_OVERLAY_FILE \
+                                                --rh_overlay /overlay_dir/$RH_OVERLAY_FILE \
+                                                --sdir /surf_subject_dir \
+                                                --output_path /output_dir/whippersnapper_image.png
+```
+
+In this example: `$SURF_SUBJECT_DIR` contains the surface files, `$OVERLAY_DIR` contains the overlays to be loaded on to the surfaces, `$OUTPUT_DIR` is the local output directory in which the snapshot will be saved, and `${LH/RH}_OVERLAY_FILE` point to the specific overlay files to load.
+
+**Note:** The `--init` flag is needed for the `xvfb-run` tool to be used correctly.
 
 ## Links:
 


### PR DESCRIPTION
## Description

This PR justs fixes the existing Dockerfile and includes instructions on how to run whippersnapper using Docker in the README.

This should be merged **after** https://github.com/m-reuter/WhipperSnapper/pull/1; until then, it is marked as a draft PR.