### PR TITLE
Integrating executable/cli in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ python3 -m pip install .
 
 ## Usage:
 
+### Local:
+
+After installing the Python package, the whippersnapper program can be run using
+the installed command line tool such as in the following example:
+```
+whippersnapper -lh $OVERLAY_DIR/$LH_OVERLAY_FILE \
+               -rh $OVERLAY_DIR/$RH_OVERLAY_FILE \
+               -sd $SURF_SUBJECT_DIR \
+               -o $OUTPUT_DIR/whippersnapper_image.png \
+```
+
+Note that adding the `--interactive` flag will start an interactive GUI that
+includes a visualization of one hemisphere side and a simple application through
+which color threshold values can be configured.
+
 ### Docker:
 
 The whippersnapper program can be run within a docker container to capture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ include-package-data = false
 include = ['whippersnapper*']
 exclude = ['whippersnapper*tests']
 
+[tool.setuptools.package-data]
+whippersnapper = ['*.ttf']
+
 [tool.black]
 line-length = 88
 target-version = ['py38']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     'pyrr',
     'pillow',
     'pyopengl',
+    'PyQt5'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ source = 'https://github.com/Deep-MI/WhipperSnapper'
 tracker = 'https://github.com/Deep-MI/WhipperSnapper/issues'
 
 [project.scripts]
-whippersnapper-sys_info = 'whippersnapper.commands.sys_info:run'
+whippersnapper = 'whippersnapper.cli:run'
 
 [tool.setuptools]
 include-package-data = false

--- a/whippersnapper/cli/__init__.py
+++ b/whippersnapper/cli/__init__.py
@@ -1,0 +1,1 @@
+from .run_whippersnapper import run

--- a/whippersnapper/cli/run_whippersnapper.py
+++ b/whippersnapper/cli/run_whippersnapper.py
@@ -38,7 +38,7 @@ from whippersnapper.config_app import ConfigWindow
 # Global variables for config app configuration state:
 current_fthresh_ = None
 current_fmax_ = None
-app_window = None
+app_window_ = None
 
 
 def show_window(hemi, overlaypath, sdir=None, caption=None, invert=False, 
@@ -69,7 +69,7 @@ def show_window(hemi, overlaypath, sdir=None, caption=None, invert=False,
     -------
     None
     """
-    global current_fthresh_, current_fmax_
+    global current_fthresh_, current_fmax_, app_window_
 
     wwidth=720
     wheight=600
@@ -114,9 +114,9 @@ def show_window(hemi, overlaypath, sdir=None, caption=None, invert=False,
  
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
 
-        if app_window is not None:
-            current_fthresh_ = app_window.get_fthresh_value()
-            current_fmax_ = app_window.get_fmax_value()
+        if app_window_ is not None:
+            current_fthresh_ = app_window_.get_fthresh_value()
+            current_fmax_ = app_window_.get_fmax_value()
         meshdata, triangles, fthresh, fmax, neg = prepare_geometry(meshpath, overlaypath, curvpath, labelpath, current_fthresh_, current_fmax_)
         shader = setup_shader(meshdata, triangles, wwidth, wheight)
 
@@ -137,7 +137,9 @@ def show_window(hemi, overlaypath, sdir=None, caption=None, invert=False,
     glfw.terminate()
 
 
-if __name__ == "__main__":
+def run():
+    global current_fthresh_, current_fmax_, app_window_
+
     parser = argparse.ArgumentParser()
     parser.add_argument('-lh', '--lh_overlay', type=str, required=True,
                         help='Absolute path to the lh overlay file.')
@@ -177,13 +179,13 @@ if __name__ == "__main__":
         app.setStyle('Fusion')                             # the default
 
         screen_geometry = app.primaryScreen().availableGeometry()
-        app_window = ConfigWindow(screen_dims=(screen_geometry.width(),
+        app_window_ = ConfigWindow(screen_dims=(screen_geometry.width(),
                                                screen_geometry.height()))
 
         # The following is a way to allow CTRL+C termination of the app:
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-        app_window.show()
+        app_window_.show()
         app.exec()
 
 


### PR DESCRIPTION
## Description

This PR addresses https://github.com/m-reuter/WhipperSnapper/issues/8 by moving the executable inside the Python package and adding a command line tool that is included in the installation. As a result, the program is exposed through the `whippersnapper` command when the package is installed; this command enables running in non-interactive or interactive mode as before.

The README was also updated with an example.